### PR TITLE
daocutil: Prefer reading from explicitly-specified files

### DIFF
--- a/daocutil/src/lib.rs
+++ b/daocutil/src/lib.rs
@@ -145,8 +145,8 @@ macro_rules! generate_main {
 							std::fs::File::open(format!("inputs/day{:02}", ident)),
 							args.next(),
 						) {
-							(Ok(file), _) => daocutil::string_from(file)?,
 							(_, Some(filename)) => daocutil::string_from(std::fs::File::open(filename)?)?,
+							(Ok(file), _) => daocutil::string_from(file)?,
 							(_, None) => daocutil::string_from(std::io::stdin())?,
 						};
 


### PR DESCRIPTION
When you run a day-solver via

```console
$ cargo run -- 13 src/examples/day13
```

it's not abundantly clear what we should do.

- If a file exists in `inputs/` that matches the parsed day identifier (in this case, `inputs/day13`), we _could_ read from that.
- If the user specifies a filename after the day identifier (in this case, `src/examples/day13`), we _could_ read from that as well.
- We could also read from `stdin`.

In this case, I'm changing the priority so that manually-specified files take precedence over the "fallback" (`inputs/` file).